### PR TITLE
Update build_cmake.yml

### DIFF
--- a/.github/workflows/Linux-pack.yml
+++ b/.github/workflows/Linux-pack.yml
@@ -142,7 +142,7 @@ jobs:
           esac
           if [ -n "${QEMU_ARCH}" ]; then
             sudo apt-get -y -qq update
-            sudo apt-get -y install qemu binfmt-support qemu-user-static
+            sudo apt-get -y install binfmt-support qemu-user-static
             docker run --rm --privileged multiarch/qemu-user-static --reset --persistent yes --credential yes
             cat /proc/sys/fs/binfmt_misc/qemu-${QEMU_ARCH}
           fi

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -107,7 +107,7 @@ jobs:
           key: ${{ runner.os }}-QtCache
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v4
         with:
           version: 5.15.2
           target:  desktop


### PR DESCRIPTION
Motivation: I don't want CI builds to fail. This PR addresses the Windows 2019 Building(CMake failures).

Problem analysis: Windows 2019 Building(CMake) runs are failing for us: https://github.com/flameshot-org/flameshot/actions/runs/13554611383/job/37886033174

![Image](https://github.com/user-attachments/assets/2c5c1b2a-2259-4064-94a3-20e227bcd765)

The failures occur in the QT Install step: https://github.com/flameshot-org/flameshot/blob/aad3a5e42e2e98af7bfb6bbda0e3d1b9c0be7497/.github/workflows/build_cmake.yml#L109-L114

I spent some time looking into it, and it looks like `jurplel/install-qt-action` is was also having issues with python version `3.13`. See this commit, which limits their python versions to 3.12 now: https://github.com/jurplel/install-qt-action/commit/fc214ccc2dadadaebf48e8e5ed6ff4297dfbb732

![Image](https://github.com/user-attachments/assets/22b6926f-fa8f-461b-8b97-5b77e92f33d0)

Proposed solution:
Going from `jurplel/install-qt-action@v2` to `jurplel/install-qt-action@v4` should fix the issue (as their commit was made to `v4`).

My tests:
This change seems to make the build pass: https://github.com/volovikariel/flameshot/actions/runs/13568251686/job/37926340193?pr=7
![image](https://github.com/user-attachments/assets/d5873366-f017-4388-8e78-be8231796bc9)
